### PR TITLE
refactor: define player as function

### DIFF
--- a/src/gesture.rs
+++ b/src/gesture.rs
@@ -6,7 +6,7 @@ use rand::{
 };
 use strum::{EnumCount, FromRepr};
 
-#[derive(EnumCount, PartialEq, Debug, Copy, Clone, FromRepr)]
+#[derive(EnumCount, PartialEq, Eq, Debug, Copy, Clone, FromRepr)]
 pub enum Gesture {
     Rock,
     Paper,
@@ -14,19 +14,19 @@ pub enum Gesture {
 }
 
 pub trait CanChallenge {
-    fn challenge(&self, other: &Gesture) -> Ordering;
+    fn challenge(&self, other: Gesture) -> Ordering;
 }
 
 impl CanChallenge for Gesture {
-    fn challenge(&self, other: &Gesture) -> Ordering {
-        if self == other {
+    fn challenge(&self, other: Gesture) -> Ordering {
+        if *self == other {
             return Ordering::Equal;
         }
 
         match (self, other) {
-            (Gesture::Rock, Gesture::Scissors) => Ordering::Greater,
-            (Gesture::Paper, Gesture::Rock) => Ordering::Greater,
-            (Gesture::Scissors, Gesture::Paper) => Ordering::Greater,
+            (Self::Rock, Self::Scissors)
+            | (Self::Paper, Self::Rock)
+            | (Self::Scissors, Self::Paper) => Ordering::Greater,
             _ => Ordering::Less,
         }
     }
@@ -55,7 +55,7 @@ mod tests {
     #[test_case(Gesture::Scissors, Gesture::Rock => Ordering::Less; "Scissors lose against rock")]
     #[test_case(Gesture::Scissors, Gesture::Scissors => Ordering::Equal; "Scissors draws against scissors")]
     fn challenge_rules_test(one: Gesture, two: Gesture) -> Ordering {
-        one.challenge(&two)
+        one.challenge(two)
     }
 
     #[test]
@@ -67,7 +67,7 @@ mod tests {
                 random_gesture == Gesture::Scissors
                     || random_gesture == Gesture::Rock
                     || random_gesture == Gesture::Paper
-            )
+            );
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,40 +1,42 @@
+#![warn(clippy::pedantic, clippy::panic, clippy::nursery)]
+#![deny(
+    clippy::all,
+    clippy::unwrap_used,
+    clippy::todo,
+    clippy::expect_used,
+    clippy::enum_glob_use
+)]
+
 use crate::gesture::{CanChallenge, Gesture};
+use crate::player::Player;
 use rand::RngExt;
 use rand::rng;
 use std::cmp::Ordering;
 use std::fmt::Display;
-use std::iter::{repeat, repeat_with};
 
 mod gesture;
+mod player;
 
 fn main() {
     let result = play_simulation();
-    println!("{}", result);
+    println!("{result}");
 }
 
 fn play_simulation() -> SimulationResult {
     let mut rng = rng();
-    let round_results =
-        (0..100).map(|_| play_round(repeat(Gesture::Rock), repeat_with(|| rng.random())));
+    let mut rock_player = || Gesture::Rock;
+    let mut random_player = move || rng.random::<Gesture>();
+    let round_results = (0..100).map(|_| play_round(&mut rock_player, &mut random_player));
     SimulationResult {
         round_results: round_results.collect(),
     }
 }
 
-fn play_round(
-    contender: impl IntoIterator<Item = Gesture>,
-    opponent: impl IntoIterator<Item = Gesture>,
-) -> RoundResult {
-    let contender_gesture = contender
-        .into_iter()
-        .next()
-        .expect("Player unexpectedly stopped to choose a gesture.");
-    let opponent_gesture = opponent
-        .into_iter()
-        .next()
-        .expect("Player unexpectedly stopped to choose a gesture.");
+fn play_round(contender: &mut dyn Player, opponent: &mut dyn Player) -> RoundResult {
+    let contender_gesture = contender.decide();
+    let opponent_gesture = opponent.decide();
 
-    match contender_gesture.challenge(&opponent_gesture) {
+    match contender_gesture.challenge(opponent_gesture) {
         Ordering::Equal => RoundResult::Draw,
         Ordering::Greater => RoundResult::ContenderWin,
         Ordering::Less => RoundResult::OpponentWin,
@@ -75,7 +77,7 @@ impl Display for SimulationResult {
                 _ => None,
             })
             .sum();
-        write! {f, "Wins={}, Draws={}, Losses={}", wins, draws, losses}
+        write!(f, "Wins={wins}, Draws={draws}, Losses={losses}")
     }
 }
 
@@ -94,31 +96,60 @@ mod tests {
 
         #[test]
         fn should_print_an_empty_result() {
-            let display = format! {"{}", SimulationResult { round_results: vec![] }};
+            let display = format!(
+                "{}",
+                SimulationResult {
+                    round_results: vec![]
+                }
+            );
             assert_eq! {display, "Wins=0, Draws=0, Losses=0"}
         }
 
         #[test]
         fn should_print_a_result_with_multiple_wins() {
-            let display = format! {"{}", SimulationResult { round_results: vec![RoundResult::ContenderWin, RoundResult::ContenderWin] }};
+            let display = format!(
+                "{}",
+                SimulationResult {
+                    round_results: vec![RoundResult::ContenderWin, RoundResult::ContenderWin]
+                }
+            );
             assert_eq! {display, "Wins=2, Draws=0, Losses=0"}
         }
 
         #[test]
         fn should_print_a_result_with_multiple_draws() {
-            let display = format! {"{}", SimulationResult { round_results: vec![RoundResult::Draw, RoundResult::Draw] }};
+            let display = format!(
+                "{}",
+                SimulationResult {
+                    round_results: vec![RoundResult::Draw, RoundResult::Draw]
+                }
+            );
             assert_eq! {display, "Wins=0, Draws=2, Losses=0"}
         }
 
         #[test]
         fn should_print_a_result_with_multiple_losses() {
-            let display = format! {"{}", SimulationResult { round_results: vec![RoundResult::OpponentWin, RoundResult::OpponentWin] }};
+            let display = format!(
+                "{}",
+                SimulationResult {
+                    round_results: vec![RoundResult::OpponentWin, RoundResult::OpponentWin]
+                }
+            );
             assert_eq! {display, "Wins=0, Draws=0, Losses=2"}
         }
 
         #[test]
         fn should_print_a_result_with_mixed_results() {
-            let display = format! {"{}", SimulationResult { round_results: vec![RoundResult::ContenderWin, RoundResult::Draw, RoundResult::OpponentWin] }};
+            let display = format!(
+                "{}",
+                SimulationResult {
+                    round_results: vec![
+                        RoundResult::ContenderWin,
+                        RoundResult::Draw,
+                        RoundResult::OpponentWin
+                    ]
+                }
+            );
             assert_eq! {display, "Wins=1, Draws=1, Losses=1"}
         }
     }
@@ -128,44 +159,46 @@ mod tests {
 
         #[test]
         fn should_return_draw() {
-            let scissors_player = repeat_with(|| Gesture::Scissors);
+            let mut scissors_player_one = || Gesture::Scissors;
+            let mut scissors_player_two = || Gesture::Scissors;
             assert_eq!(
-                play_round(scissors_player, scissors_player),
+                play_round(&mut scissors_player_one, &mut scissors_player_two),
                 RoundResult::Draw
             );
         }
 
         #[test]
         fn should_return_win() {
-            let scissors_player = repeat_with(|| Gesture::Scissors);
-            let paper_player = repeat_with(|| Gesture::Paper);
+            let mut scissors_player = || Gesture::Scissors;
+            let mut paper_player = || Gesture::Paper;
 
             assert_eq!(
-                play_round(scissors_player, paper_player),
+                play_round(&mut scissors_player, &mut paper_player),
                 RoundResult::ContenderWin
             );
         }
 
         #[test]
         fn should_return_loss() {
-            let scissors_player = repeat_with(|| Gesture::Scissors);
-            let rock_player = repeat_with(|| Gesture::Rock);
+            let mut scissors_player = || Gesture::Scissors;
+            let mut rock_player = || Gesture::Rock;
 
             assert_eq!(
-                play_round(scissors_player, rock_player),
+                play_round(&mut scissors_player, &mut rock_player),
                 RoundResult::OpponentWin
             );
         }
 
         #[test]
         fn should_work_multiple_times() {
-            let scissors_player = repeat_with(|| Gesture::Scissors);
+            let mut scissors_player_one = || Gesture::Scissors;
+            let mut scissors_player_two = || Gesture::Scissors;
             assert_eq!(
-                play_round(scissors_player, scissors_player),
+                play_round(&mut scissors_player_one, &mut scissors_player_two),
                 RoundResult::Draw
             );
             assert_eq!(
-                play_round(scissors_player, scissors_player),
+                play_round(&mut scissors_player_one, &mut scissors_player_two),
                 RoundResult::Draw
             );
         }

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,25 @@
+use crate::gesture::Gesture;
+
+pub trait Player {
+    fn decide(&mut self) -> Gesture;
+}
+
+impl<F> Player for F
+where
+    F: FnMut() -> Gesture,
+{
+    fn decide(&mut self) -> Gesture {
+        self()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn define_player_as_function() {
+        let mut player = || Gesture::Paper;
+        assert_eq!(player.decide(), Gesture::Paper);
+    }
+}


### PR DESCRIPTION
Define a player as a function to avoid dealing with ending iterators.
In fact a player is naturally defined by having the ability to make
a turn at every moment. An iterator can be finite.